### PR TITLE
dedicated jquery.datatables.min.js browser resource

### DIFF
--- a/collective/js/datatables/configure.zcml
+++ b/collective/js/datatables/configure.zcml
@@ -31,6 +31,10 @@
 
   <browser:resource
     name="jquery.datatables.js"
+    file="resources/media/js/jquery.dataTables.js" />
+
+  <browser:resource
+    name="jquery.datatables.min.js"
     file="resources/media/js/jquery.dataTables.min.js" />
 
   <browser:resource


### PR DESCRIPTION
this one -> https://github.com/collective/collective.js.datatables/commit/347ecfd578f04bc647021bfbb450990481bd4b0e -> manually disables AMD. In Plone 4 this file never gets delivered because the minified version is registered as browser resource. So I guess this file has been used as part of some grunt compilation? In Plone 5 AMD now applies on the minified version which actually causes troubles with "old-school" JS

Meanwhile I defined a dedicated browser resource with the minified version and deliver the uncompressed one by default. This causes no behavioral change for p4.

How should we deal with this with focus on P4/P5 compatibility?